### PR TITLE
Ensures each line in a post ends with 2 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,13 @@ Embed:
 ## Fix New Lines in Posts
 Automatically ensures all lines have two spaces at the end, so Markdown will render new lines. Without two spaces at the end, text written on different lines (*without a blank line between them*) will render in your post as being on one line.
 
-**Note:** The `<script src=...>` below will apply fixes automatically when you click `Save as draft` or `Publish`. If you copy+paste the Code, you can set `const autofix = false;` to add a 'Fix new lines' button instead.
-
 [Code](/plugins/newline-fixer.js)
 
 Embed:
 ```
-<script src="https://cdn.jsdelivr.net/gh/hermanmartinus/bear-plugins/plugins/newline-fixer.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/hermanmartinus/bear-plugins/plugins/newline-fixer.js"
+    data-autofix="true"
+></script>
 ```
+**Configuration:** Set `data-autofix="false"` (*must be lowercase*) too add a 'Fix new lines' button. Otherwise, the newline fix is applied automatically when clicking 'Publish' or 'Save as draft'.
 

--- a/README.md
+++ b/README.md
@@ -104,3 +104,15 @@ Embed:
 <script src="https://cdn.jsdelivr.net/gh/hermanmartinus/bear-plugins/plugins/dashboard-post-counter.js"></script>
 ```
 
+## Fix New Lines in Posts
+Automatically ensures all lines have two spaces at the end, so Markdown will render new lines. Without two spaces at the end, text written on different lines (*without a blank line between them*) will render in your post as being on one line.
+
+**Note:** The `<script src=...>` below will apply fixes automatically when you click `Save as draft` or `Publish`. If you copy+paste the Code, you can set `const autofix = false;` to add a 'Fix new lines' button instead.
+
+[Code](/plugins/newline-fixer.js)
+
+Embed:
+```
+<script src="https://cdn.jsdelivr.net/gh/hermanmartinus/bear-plugins/plugins/newline-fixer.js"></script>
+```
+

--- a/plugins/newline-fixer.js
+++ b/plugins/newline-fixer.js
@@ -9,9 +9,10 @@
     ? document.addEventListener.bind(this,'DOMContentLoaded')  
     : function(f){f();}.bind(this)
 ).call(this,
-  function() {
+  function(autofix_config) {
     // when 'autofix = false;', a button will be added to your 'New Post' page. When 'autofix = true', the fix will be added automatically on-submission.
-    const autofix = true;
+    let autofix = true;
+    if (autofix_config == "false")autofix = false;
   
     // check if we're on a page with a new post form
     const form = document.querySelector('form.post-form');
@@ -36,7 +37,9 @@
       // add the button to your 'New Post' page
       document.querySelector('.sticky-controls').appendChild(btn);
     }
-  }
+  }.bind(this, 
+    document.currentScript?.dataset?.autofix,
+    )
 );
 
 /** ensures every line in the post content has two spaces at the end */

--- a/plugins/newline-fixer.js
+++ b/plugins/newline-fixer.js
@@ -1,14 +1,11 @@
 /**
-*
-* WIP - I can't figure out how to get the autofix onsubmit to work. I think I have to block submission THEN call form.submit() which I was hoping to avoid. I could try click events on the buttons, but that is somewhat prone to problems, like if someone submits by pressing enter.
-*
 * This adds two spaces to the ends of every line in your post. 
 *
 * In Markdown, new lines only render if there is a full blank line between paragraphs or two spaces at the end of each line. This plugin manages the two-spaces requirement for you.
 * Created by ReedyBear, see https://reedybear.bearblog.dev/bearblog/ for other creations.
 */
 
-(function(){
+document.addEventListener('DOMContentLoaded', function() {
   // when 'autofix = false;', a button will be added to your 'New Post' page. When 'autofix = true', the fix will be added automatically on-submission.
   const autofix = true;
 
@@ -18,25 +15,34 @@
       return; // stop execution of we're not on a new post page
   }
   if (autofix){
-    //form.addEventListener('submit', fix_new_lines);
-    const body_node = document.querySelector('#body_content');
-    body_node.addEventListener('change', fix_new_lines);
-  } else {
+    form.addEventListener('submit', fix_new_lines);
+  } 
+  if (true){
     // create a new button element
     const btn = document.createElement('button');
     btn.classList.add('markdown_line_fixer');
-    btn.setAttribute('onclick', "event.preventDefault();fix_new_lines();");
+    btn.setAttribute('onclick', "event.preventDefault();fix_new_lines(event);");
     btn.innerText = 'Fix new lines';
     // add the button to your 'New Post' page
     document.querySelector('.sticky-controls').appendChild(btn);
   }
-})();
+});
 
 
-function fix_new_lines(){
+function fix_new_lines(event){
+  console.log('fix new lines');
+  //console.log(event);
+  //console.log(event.type);
   const body_node = document.querySelector('#body_content');
   const body = body_node.value;
   const regex = /([^\n ])( {0,1})\n/g;
   const fixed_body = body.replaceAll(regex, "$1  \n");
   body_node.value = fixed_body;
+  if (event.type == 'submit'
+      && body != fixed_body){
+      console.log('prevent submission');
+      event.preventDefault();
+      const form = document.querySelector('form.post-form');
+      form.requestSubmit();
+  }
 }

--- a/plugins/newline-fixer.js
+++ b/plugins/newline-fixer.js
@@ -5,34 +5,39 @@
 * Created by ReedyBear, see https://reedybear.bearblog.dev/bearblog/ for other creations.
 */
 
-document.addEventListener('DOMContentLoaded', function() {
-  // when 'autofix = false;', a button will be added to your 'New Post' page. When 'autofix = true', the fix will be added automatically on-submission.
-  const autofix = true;
-
-  // check if we're on a page with a new post form
-  const form = document.querySelector('form.post-form');
-  if (form == null) {
-      return; // stop execution of we're not on a new post page
-  }
-  if (autofix){
-    // update the submit buttons so the fix is applied automatically when they are clicked
-    const submit_buttons = document.querySelectorAll('.sticky-controls > button[type="submit"]');
-    for (const button of submit_buttons){
-        button.setAttribute('onclick', 
-            button.getAttribute('onclick')
-            +";fix_new_lines(event);"
-            );
+(document.readyState === "loading" 
+    ? document.addEventListener.bind(this,'DOMContentLoaded')  
+    : function(f){f();}.bind(this)
+).call(this,
+  function() {
+    // when 'autofix = false;', a button will be added to your 'New Post' page. When 'autofix = true', the fix will be added automatically on-submission.
+    const autofix = true;
+  
+    // check if we're on a page with a new post form
+    const form = document.querySelector('form.post-form');
+    if (form == null) {
+        return; // stop execution of we're not on a new post page
     }
-  } else {
-    // create a new button, which you can click to apply the new lines fix
-    const btn = document.createElement('button');
-    btn.classList.add('markdown_line_fixer');
-    btn.setAttribute('onclick', "event.preventDefault();fix_new_lines(event);");
-    btn.innerText = 'Fix new lines';
-    // add the button to your 'New Post' page
-    document.querySelector('.sticky-controls').appendChild(btn);
+    if (autofix){
+      // update the submit buttons so the fix is applied automatically when they are clicked
+      const submit_buttons = document.querySelectorAll('.sticky-controls > button[type="submit"]');
+      for (const button of submit_buttons){
+          button.setAttribute('onclick', 
+              button.getAttribute('onclick')
+              +";fix_new_lines(event);"
+              );
+      }
+    } else {
+      // create a new button, which you can click to apply the new lines fix
+      const btn = document.createElement('button');
+      btn.classList.add('markdown_line_fixer');
+      btn.setAttribute('onclick', "event.preventDefault();fix_new_lines(event);");
+      btn.innerText = 'Fix new lines';
+      // add the button to your 'New Post' page
+      document.querySelector('.sticky-controls').appendChild(btn);
+    }
   }
-});
+);
 
 /** ensures every line in the post content has two spaces at the end */
 function fix_new_lines(event){

--- a/plugins/newline-fixer.js
+++ b/plugins/newline-fixer.js
@@ -1,5 +1,5 @@
 /**
-* Ensures each line in your post has two spaces at the end. Markdown requires either a blank line between paragraphs or two spaces at the end of a line in order to render as separate paragraphs.
+* Ensures each line in your post has two spaces at the end, so that markdown renders new lines.
 *
 * change `const autofix = true;` to `const autofix = false;` to add a 'Fix new lines' button instead of fixing automatically on submission.
 * Created by ReedyBear, see https://reedybear.bearblog.dev/bearblog/ for other creations.
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
       return; // stop execution of we're not on a new post page
   }
   if (autofix){
+    // update the submit buttons so the fix is applied automatically when they are clicked
     const submit_buttons = document.querySelectorAll('.sticky-controls > button[type="submit"]');
     for (const button of submit_buttons){
         button.setAttribute('onclick', 
@@ -23,7 +24,7 @@ document.addEventListener('DOMContentLoaded', function() {
             );
     }
   } else {
-    // create a new button element
+    // create a new button, which you can click to apply the new lines fix
     const btn = document.createElement('button');
     btn.classList.add('markdown_line_fixer');
     btn.setAttribute('onclick', "event.preventDefault();fix_new_lines(event);");
@@ -33,11 +34,13 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
-
+/** ensures every line in the post content has two spaces at the end */
 function fix_new_lines(event){
   const body_node = document.querySelector('#body_content');
   const body = body_node.value;
+  // regex finds lines that have text on them and do not end with 2 spaces.
   const regex = /([^\n ])( {0,1})\n/g;
+  // The $1 makes sure that the last character of each line does not get deleted.
   const fixed_body = body.replaceAll(regex, "$1  \n");
   body_node.value = fixed_body;
 }

--- a/plugins/newline-fixer.js
+++ b/plugins/newline-fixer.js
@@ -1,7 +1,7 @@
 /**
-* This adds two spaces to the ends of every line in your post. 
+* Ensures each line in your post has two spaces at the end. Markdown requires either a blank line between paragraphs or two spaces at the end of a line in order to render as separate paragraphs.
 *
-* In Markdown, new lines only render if there is a full blank line between paragraphs or two spaces at the end of each line. This plugin manages the two-spaces requirement for you.
+* change `const autofix = true;` to `const autofix = false;` to add a 'Fix new lines' button instead of fixing automatically on submission.
 * Created by ReedyBear, see https://reedybear.bearblog.dev/bearblog/ for other creations.
 */
 
@@ -15,9 +15,14 @@ document.addEventListener('DOMContentLoaded', function() {
       return; // stop execution of we're not on a new post page
   }
   if (autofix){
-    form.addEventListener('submit', fix_new_lines);
-  } 
-  if (true){
+    const submit_buttons = document.querySelectorAll('.sticky-controls > button[type="submit"]');
+    for (const button of submit_buttons){
+        button.setAttribute('onclick', 
+            button.getAttribute('onclick')
+            +";fix_new_lines(event);"
+            );
+    }
+  } else {
     // create a new button element
     const btn = document.createElement('button');
     btn.classList.add('markdown_line_fixer');
@@ -30,19 +35,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
 
 function fix_new_lines(event){
-  console.log('fix new lines');
-  //console.log(event);
-  //console.log(event.type);
   const body_node = document.querySelector('#body_content');
   const body = body_node.value;
   const regex = /([^\n ])( {0,1})\n/g;
   const fixed_body = body.replaceAll(regex, "$1  \n");
   body_node.value = fixed_body;
-  if (event.type == 'submit'
-      && body != fixed_body){
-      console.log('prevent submission');
-      event.preventDefault();
-      const form = document.querySelector('form.post-form');
-      form.requestSubmit();
-  }
 }

--- a/plugins/newline-fixer.js
+++ b/plugins/newline-fixer.js
@@ -1,0 +1,42 @@
+/**
+*
+* WIP - I can't figure out how to get the autofix onsubmit to work. I think I have to block submission THEN call form.submit() which I was hoping to avoid. I could try click events on the buttons, but that is somewhat prone to problems, like if someone submits by pressing enter.
+*
+* This adds two spaces to the ends of every line in your post. 
+*
+* In Markdown, new lines only render if there is a full blank line between paragraphs or two spaces at the end of each line. This plugin manages the two-spaces requirement for you.
+* Created by ReedyBear, see https://reedybear.bearblog.dev/bearblog/ for other creations.
+*/
+
+(function(){
+  // when 'autofix = false;', a button will be added to your 'New Post' page. When 'autofix = true', the fix will be added automatically on-submission.
+  const autofix = true;
+
+  // check if we're on a page with a new post form
+  const form = document.querySelector('form.post-form');
+  if (form == null) {
+      return; // stop execution of we're not on a new post page
+  }
+  if (autofix){
+    //form.addEventListener('submit', fix_new_lines);
+    const body_node = document.querySelector('#body_content');
+    body_node.addEventListener('change', fix_new_lines);
+  } else {
+    // create a new button element
+    const btn = document.createElement('button');
+    btn.classList.add('markdown_line_fixer');
+    btn.setAttribute('onclick', "event.preventDefault();fix_new_lines();");
+    btn.innerText = 'Fix new lines';
+    // add the button to your 'New Post' page
+    document.querySelector('.sticky-controls').appendChild(btn);
+  }
+})();
+
+
+function fix_new_lines(){
+  const body_node = document.querySelector('#body_content');
+  const body = body_node.value;
+  const regex = /([^\n ])( {0,1})\n/g;
+  const fixed_body = body.replaceAll(regex, "$1  \n");
+  body_node.value = fixed_body;
+}


### PR DESCRIPTION
`line 1\nline 2\nline 3` would normally render as `<p>line1 line 2 line 3</p>`

This plugin modifies it so that `line 1\nline 2\nline 3` becomes `line 1  \n line 2  \nline3` so that it renders as `<p>line 1<br>line 2<br>line 3</p>`

By default the script applies the fix automatically when `Publish` or `Save as draft` is clicked. I tried to use the `submit` event on the form, but it just wouldn't work and I couldn't figure out why. The script takes care to preserve the existing `onclick` code on the `type=submit` buttons, which you're using to set `#publish.value` to true/false.

When copy+pasting the code in, `const autofix = true;` can be changed to `const autofix = false;` to add a 'Fix new lines' button instead of applying the fixes automatically.

This plugin does not modify blank lines, and does not modify lines that already have 2 or more spaces at the end.