### PR TITLE
tag-based post footers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,15 @@ Embed:
 ```
 **Configuration:** Set `data-autofix="false"` (*must be lowercase*) too add a 'Fix new lines' button. Otherwise, the newline fix is applied automatically when clicking 'Publish' or 'Save as draft'.
 
+## Add Footers Based on Tags
+Lets you add footers to posts based on the tags on that post, simply by clicking a button. Adds a page to edit configured footers. You can access this page via the link at the bottom right of New Post/Edit Post pages.
+
+[Code](/plugins/tagbased-post-footers.js)
+
+Embed:
+```
+<script src="https://cdn.jsdelivr.net/gh/hermanmartinus/bear-plugins/plugins/tagbased-post-footers.js"
+    data-first_tag_only="false"
+></script>
+```
+**Configuration:** Set `data-first_tag_only="true"` (*must be lowercase*) to only add a footer for the first tag in your taglist. By default adds configured footer for every tag in your taglist.

--- a/plugins/automatic-post-footers.js
+++ b/plugins/automatic-post-footers.js
@@ -1,5 +1,7 @@
 /** Automatically add footers to your posts based upon the tags you've added to the post
 *
+*  Add `data-first_tag_only="true"` to only add one footer to each post instead of adding footers for every tag.
+*
 * This plugin developed by: ReedyBear https://reedybear.bearblog.dev/bearblog/
 */
 
@@ -48,9 +50,9 @@
     )
 );
 
-function insert_auto_footer(show_first_only){
+function insert_tagbased_footer(show_first_only){
     const header = document.querySelector('#header_content');
-    const tag_match = header.innerHTML.match(/tags:(.+)/);
+    const tag_match = header.innerHTML.match(/tags:([^\<]+)/);
     tag_list = tag_match[1].trim().split(",").map((tag)=>tag.trim());
     const post_footer = [];
     for (const tag of tag_list){

--- a/plugins/automatic-post-footers.js
+++ b/plugins/automatic-post-footers.js
@@ -19,9 +19,25 @@
    * @param config2 bool true or false [tell me what it does]
    */
   function(first_tag_only) {
+
+      
+      // this goes in your main function
+      if (window.location.href.endsWith('#manage-tagbased-footers')){
+          show_tagbased_footer_editor_page();
+          return;
+      }
+      
       if (!$textarea)return;
       const controls = document.querySelector('.sticky-controls');
       if (controls == null) return;
+
+      const link_container = document.querySelector('span.helptext.sticky > span:nth-child(2)');
+      const link = document.createElement('a');
+      link.href = '#manage-tagbased-footers';
+      link.target = '_blank';
+      link.text = 'Manage Auto-Footers';
+      link_container.appendChild(document.createTextNode(' | '));
+      link_container.appendChild(link);
 
       let is_first_only;
       if (first_tag_only=='true')is_first_only = 'true';
@@ -58,12 +74,6 @@ function insert_auto_footer(){
 }
 
 function get_footer_content(tag){
-    // TODO use local storage
-    const footers = {
-        abc: "abc footer content",
-        def: "def footer content",
-        "qr-zx_59": "qr whatever blah blah"
-    };
     const footers_string = localStorage.getItem('tagbased_post_footers');
     if (footers_string == null) return null;
     
@@ -81,6 +91,45 @@ function store_footer_content(tag, content){
     localStorage.setItem('tagbased_post_footers', JSON.stringify(footers));
 }
 
+
+/**
+ * Show your plugin's page
+ *
+ * @param force_refresh boolean true\false. Use `false` when displaying initially, and use `true` when forcing a refresh
+ */
+function show_tagbased_footer_editor_page(force_refresh){
+    // edit these settings
+    const page_class = "tagbased-footer-editor"; 
+    const page_name = "Automatic Footer Manager | Bear Blog";
+
+    // make sure it's an initial load OR force_refresh is true
+    const main = document.querySelector('body > main');
+    if (main.classList.contains(page_class) 
+        && force_refresh !== true)return;
+
+    main.classList.add(page_class);
+    main.innerHTML = '';
+
+    document.querySelector('head title').innerText = page_name;
+
+    // TODO: Set the correct function name here, or inline the page HTML
+    const template = get_tagbased_footer_editor_page_template();
+
+    main.innerHTML = template;
+
+    // dynamically interact with your page now that the template is loaded
+    // for example: the plugin manager loads the list of plugins and inserts them into the appropriate part of the template
+}
+
+function get_tagbased_footer_editor_page_template(){
+   const template =  
+    `
+        <h1>Automatic Footer Manager</h1>
+        <p>Edit your automatic footers, which are inserted depending on the tags you add to your post. On the Plugin Manager page, you can configure whether footers are inserted for all tags, or just for the first listed tag.</p>
+        <div class="tag_list"></div>
+    `;
+    return template;
+}
 
 
 

--- a/plugins/automatic-post-footers.js
+++ b/plugins/automatic-post-footers.js
@@ -1,15 +1,14 @@
 /** Automatically add footers to your posts based upon the tags you've added to the post
 *
-* ADDITIONAL INSTRUCTIONS / DOCUMENTATION
 * This plugin developed by: ReedyBear https://reedybear.bearblog.dev/bearblog/
 */
 
 // TODO:
 // - Add page to create footers
-// - use local storage instead of placeholder array
-// - Re-think how I'm handling the AUTO_POST_FOOTER_START/END stuff. It's just ugly. A simple insert at the end might be better. Or referencing the last occurence of `---` might be better. Making this somewhat configurable might also be best
-// - consider whether it should use a button or actually be automatic (*it could be automatically updated when tags change?*)
-// - Consider adding a setting for whether we just add a footer for the FIRST tag, or if we add it for ALL tags
+// - DONE use local storage instead of placeholder array
+// - DONE (simple append on button click) Re-think how I'm handling the AUTO_POST_FOOTER_START/END stuff. It's just ugly. A simple insert at the end might be better. Or referencing the last occurence of `---` might be better. Making this somewhat configurable might also be best
+// - DONE (button always) consider whether it should use a button or actually be automatic (*it could be automatically updated when tags change?*)
+// - DONE (setting present) Consider adding a setting for whether we just add a footer for the FIRST tag, or if we add it for ALL tags
 
 (document.readyState === "loading" 
     ? document.addEventListener.bind(this,'DOMContentLoaded')  
@@ -19,64 +18,43 @@
    * @param config1 string [tell me what value is expected and what it does]
    * @param config2 bool true or false [tell me what it does]
    */
-  function(config1, config2) {
+  function(first_tag_only) {
       if (!$textarea)return;
       const controls = document.querySelector('.sticky-controls');
       if (controls == null) return;
 
-      $textarea.value = "i am a post body\n\nand another para";
-
+      let is_first_only;
+      if (first_tag_only=='true')is_first_only = 'true';
+      else is_first_only = 'false';
         
       // create a new button element
       const toc_btn = document.createElement('button');
       toc_btn.classList.add('insert_footer');
-      toc_btn.setAttribute('onclick', "event.preventDefault();insert_auto_footer();");
+      toc_btn.setAttribute('onclick', "event.preventDefault();insert_tagbased_footer("+is_first_only+");");
       toc_btn.innerText = "Insert Footer";
       // add the button to your 'New Post' page
       controls.appendChild(toc_btn);
   }.bind(this,
-    document.currentScript?.dataset?.config1, // corresponds to `data-config1="some setting"`
-    document.currentScript?.dataset?.config2,
+    document.currentScript?.dataset?.first_tag_only, //
     )
 );
 
 function insert_auto_footer(){
     const header = document.querySelector('#header_content');
-    const tag_match = header.innerHTML.match(/tags:([ ,a-zA-Z0-9\-\_]+)/);
+    const tag_match = header.innerHTML.match(/tags:(.+)/);
     tag_list = tag_match[1].trim().split(",").map((tag)=>tag.trim());
     const post_footer = [];
     for (const tag of tag_list){
         const footer_content = get_footer_content(tag);
+        if (footer_content == null) continue;
         post_footer.push(footer_content);
     }
 
     const post_body = $textarea.value;
-    const auto_header = '<!-- AUTO_POST_FOOTER_START -->';
-    const auto_footer = '<!-- AUTO_POST_FOOTER_END -->'
-    const auto_start = post_body.indexOf(auto_header);
-    if (auto_start == -1){
-        console.log("no auto start");
-        $textarea.value = 
-          post_body+"\n\n"
-          +auto_header+"\n\n---\n\n"
-          +post_footer.join("\n\n")
-          +"\n\n"+auto_footer;
-    } else {
-      console.log("footer exists");
-
-        const auto_end = post_body.indexOf(auto_footer);
-        console.log(auto_start);
-        console.log(auto_end);
-        console.log(post_body.substr(auto_start, (auto_end - auto_start) + auto_footer.length));
-        $textarea.value =
-            post_body.replace(
-              post_body.substr(auto_start, (auto_end - auto_start) + auto_footer.length),
-              auto_header+"\n\n---\n\n"
-              +post_footer.join("\n\n")
-              +"\n\n"+auto_footer
-            );
-            
-    }
+     $textarea.value = 
+          post_body
+          +"\n\n---\n\n"
+          +post_footer.join("\n\n");
 }
 
 function get_footer_content(tag){
@@ -86,7 +64,21 @@ function get_footer_content(tag){
         def: "def footer content",
         "qr-zx_59": "qr whatever blah blah"
     };
+    const footers_string = localStorage.getItem('tagbased_post_footers');
+    if (footers_string == null) return null;
+    
+    const footers = JSON.parse(footers_string);
     return footers[tag];
+}
+
+function store_footer_content(tag, content){
+    const footers_string = localStorage.getItem('tagbased_post_footers');
+    let footers;
+    if (footers_string == null) footers = {};
+    else footers = JSON.parse(footers_string);
+
+    footers[tag] = content;
+    localStorage.setItem('tagbased_post_footers', JSON.stringify(footers));
 }
 
 

--- a/plugins/automatic-post-footers.js
+++ b/plugins/automatic-post-footers.js
@@ -1,0 +1,97 @@
+/** Automatically add footers to your posts based upon the tags you've added to the post
+*
+* ADDITIONAL INSTRUCTIONS / DOCUMENTATION
+* This plugin developed by: ReedyBear https://reedybear.bearblog.dev/bearblog/
+*/
+
+// TODO:
+// - Add page to create footers
+// - use local storage instead of placeholder array
+// - Re-think how I'm handling the AUTO_POST_FOOTER_START/END stuff. It's just ugly. A simple insert at the end might be better. Or referencing the last occurence of `---` might be better. Making this somewhat configurable might also be best
+// - consider whether it should use a button or actually be automatic (*it could be automatically updated when tags change?*)
+// - Consider adding a setting for whether we just add a footer for the FIRST tag, or if we add it for ALL tags
+
+(document.readyState === "loading" 
+    ? document.addEventListener.bind(this,'DOMContentLoaded')  
+    : function(f){f();}.bind(this)
+).call(this,
+  /**
+   * @param config1 string [tell me what value is expected and what it does]
+   * @param config2 bool true or false [tell me what it does]
+   */
+  function(config1, config2) {
+      if (!$textarea)return;
+      const controls = document.querySelector('.sticky-controls');
+      if (controls == null) return;
+
+      $textarea.value = "i am a post body\n\nand another para";
+
+        
+      // create a new button element
+      const toc_btn = document.createElement('button');
+      toc_btn.classList.add('insert_footer');
+      toc_btn.setAttribute('onclick', "event.preventDefault();insert_auto_footer();");
+      toc_btn.innerText = "Insert Footer";
+      // add the button to your 'New Post' page
+      controls.appendChild(toc_btn);
+  }.bind(this,
+    document.currentScript?.dataset?.config1, // corresponds to `data-config1="some setting"`
+    document.currentScript?.dataset?.config2,
+    )
+);
+
+function insert_auto_footer(){
+    const header = document.querySelector('#header_content');
+    const tag_match = header.innerHTML.match(/tags:([ ,a-zA-Z0-9\-\_]+)/);
+    tag_list = tag_match[1].trim().split(",").map((tag)=>tag.trim());
+    const post_footer = [];
+    for (const tag of tag_list){
+        const footer_content = get_footer_content(tag);
+        post_footer.push(footer_content);
+    }
+
+    const post_body = $textarea.value;
+    const auto_header = '<!-- AUTO_POST_FOOTER_START -->';
+    const auto_footer = '<!-- AUTO_POST_FOOTER_END -->'
+    const auto_start = post_body.indexOf(auto_header);
+    if (auto_start == -1){
+        console.log("no auto start");
+        $textarea.value = 
+          post_body+"\n\n"
+          +auto_header+"\n\n---\n\n"
+          +post_footer.join("\n\n")
+          +"\n\n"+auto_footer;
+    } else {
+      console.log("footer exists");
+
+        const auto_end = post_body.indexOf(auto_footer);
+        console.log(auto_start);
+        console.log(auto_end);
+        console.log(post_body.substr(auto_start, (auto_end - auto_start) + auto_footer.length));
+        $textarea.value =
+            post_body.replace(
+              post_body.substr(auto_start, (auto_end - auto_start) + auto_footer.length),
+              auto_header+"\n\n---\n\n"
+              +post_footer.join("\n\n")
+              +"\n\n"+auto_footer
+            );
+            
+    }
+}
+
+function get_footer_content(tag){
+    // TODO use local storage
+    const footers = {
+        abc: "abc footer content",
+        def: "def footer content",
+        "qr-zx_59": "qr whatever blah blah"
+    };
+    return footers[tag];
+}
+
+
+
+
+
+
+

--- a/plugins/plugin-manager.js
+++ b/plugins/plugin-manager.js
@@ -79,6 +79,13 @@ function get_available_plugins(){
                 creator_name: "ReedyBear",
                 creator_url: "https://reedybear.bearblog.dev/bearblog/"
             },
+            "/plugins/tagbased-post-footers.js": {
+                name: "Footers Based on Tags",
+                path: "/plugins/tagbased-post-footers.js",
+                description: "Click a button to add custom footers to a post based upon its tags. Adds a page to edit configured footers. You can access this page via the link at the bottom right of New Post/Edit Post pages.",
+                creator_name: "ReedyBear",
+                creator_url: "https://reedybear.bearblog.dev/bearblog/"
+            },
             "/plugins/plugin-manager.js": {
                 disable: true,
                 name: "Plugin Manager (installed)",
@@ -87,6 +94,7 @@ function get_available_plugins(){
                 creator_name: "ReedyBear",
                 creator_url: "https://reedybear.bearblog.dev/bearblog/"
             }
+
         }
         //,blog:{ // blog plugin manager is not yet available
             //"/plugins/pagination.js":{

--- a/plugins/plugin-manager.js
+++ b/plugins/plugin-manager.js
@@ -84,7 +84,15 @@ function get_available_plugins(){
                 path: "/plugins/tagbased-post-footers.js",
                 description: "Click a button to add custom footers to a post based upon its tags. Adds a page to edit configured footers. You can access this page via the link at the bottom right of New Post/Edit Post pages.",
                 creator_name: "ReedyBear",
-                creator_url: "https://reedybear.bearblog.dev/bearblog/"
+                creator_url: "https://reedybear.bearblog.dev/bearblog/",
+                editable: {
+                    first_tag_only: {
+                        label: "First Tag Only",
+                        default: "false",
+                        description: "Set to <strong>true</strong> (<i>must be lowercase,</i>) to only add footers for the first tag in the list. By default, adds a footer for every tag in the taglist.",
+                        type: "text"
+                    }
+                }
             },
             "/plugins/plugin-manager.js": {
                 disable: true,

--- a/plugins/tagbased-post-footers.js
+++ b/plugins/tagbased-post-footers.js
@@ -1,4 +1,4 @@
-/** Automatically add footers to your posts based upon the tags you've added to the post
+/** Automatically add footers to your posts based upon the tags you've added to the post. Adds a page for managing these footers. Adds a button the new post/edit post page.
 *
 *  Add `data-first_tag_only="true"` to only add one footer to each post instead of adding footers for every tag.
 *

--- a/plugins/tagbased-post-footers.js
+++ b/plugins/tagbased-post-footers.js
@@ -52,7 +52,7 @@
 
 function insert_tagbased_footer(show_first_only){
     const header = document.querySelector('#header_content');
-    const tag_match = header.innerHTML.match(/tags:([^\<]+)/);
+    const tag_match = header.innerHTML.match(/tags:(\<\/b\>)?([^\<\n]+)/);
     tag_list = tag_match[1].trim().split(",").map((tag)=>tag.trim());
     const post_footer = [];
     for (const tag of tag_list){

--- a/plugins/tagbased-post-footers.js
+++ b/plugins/tagbased-post-footers.js
@@ -196,7 +196,6 @@ function add_tagbased_footer_form(){
 
     delete_button.addEventListener('click',
         function(fieldset){
-            console.log(fieldset);
             const tag_node = fieldset.querySelector('input[name="tag"]');
             const tag = tag_node.value.trim();
             if (!confirm('Delete footer for tag "'+tag+'"?'))return;

--- a/plugins/tagbased-post-footers.js
+++ b/plugins/tagbased-post-footers.js
@@ -52,7 +52,7 @@
 
 function insert_tagbased_footer(show_first_only){
     const header = document.querySelector('#header_content');
-    const tag_match = header.innerHTML.match(/tags:(\<\/b\>)?([^\<\n]+)/);
+    const tag_match = header.innerHTML.match(/tags:(?:\<\/b\>)?([^\<\n]+)/);
     tag_list = tag_match[1].trim().split(",").map((tag)=>tag.trim());
     const post_footer = [];
     for (const tag of tag_list){


### PR DESCRIPTION
Adds a button the New Post\Edit Post page to insert footers. Footers are inserted based upon which tags are listed in the `tags:...` list in the header. Footers are configured via a custom page. The link to that page is in the bottom right on the new post / edit post page.

Plugin has been added to the README and to the plugin manager. Updated Plugin manager has been tested and this plugin is installable. Of course plugin manager can't be fully tested until PR is merged bc the new plugin's script isn't actually deliverable by jsdelivr until then.