### PR TITLE
Adding `ace-editor` plugin

### DIFF
--- a/plugins/ace-editor/ace-editor-loader.js
+++ b/plugins/ace-editor/ace-editor-loader.js
@@ -1,0 +1,45 @@
+(document.readyState === "loading"
+    ? document.addEventListener.bind(this, 'DOMContentLoaded')
+    : function (f) { f(); }.bind(this)
+).call(this,
+    function () {
+        // Only run if the page has an element named `$textarea`
+        if ($textarea) {
+            // Make the default text area invisible. It still exists and holds the current page or post content, but it just isn't shown on screen
+            $textarea.style.display = "none";
+
+            // ace-editor needs a div with a given ID to be created.
+            // This creates a new div right after the invisible text area
+            // to be transformed into the editor
+            $aceDiv = document.createElement("div");
+            $aceDiv.id = "ace-editor";
+            $aceDiv.style.height = "700px";
+            $textarea.insertAdjacentElement('afterend', $aceDiv);
+
+            // Now that the div is ready, create the editor
+            var editor = ace.edit("ace-editor");
+
+            // Apply theme and set the editing mode to markdown so syntax highlighting works
+            editor.setTheme("ace/theme/solarized_dark");
+            editor.session.setMode("ace/mode/markdown");
+
+            // Populate ace-editor with the existing page or post content in the hidden text area
+            editor.setValue($textarea.value);
+
+            // Reset the cursor back to the top of the editor
+            editor.gotoLine(0);
+
+            // Allow scrolling past the last line of the editor. This is a personal preference, but I think it works well in this case!
+            editor.setOption("scrollPastEnd", 0.5);
+
+            // Wrap long lines at the editor's width to avoid having to scroll horizontally
+            editor.session.setUseWrapMode(true);
+
+            // When you click the "Publish" button, Bear saves the text that is in the original hidden text area, not the text in ace-editor
+
+            // These last lines make sure that any modifications to the text in ace-editor get synced to the hidden text area, so that your edited content gets saved when you click "Publish"
+            editor.session.on("change", function (delta) {
+                $textarea.value = editor.getValue();
+            });
+        }
+    });

--- a/plugins/ace-editor/bear-ace-theme.css
+++ b/plugins/ace-editor/bear-ace-theme.css
@@ -1,0 +1,177 @@
+/*
+ * This is a customized version of ace-editor's Solarized Dark theme,
+ * made specifically for Bear Blog.
+ *
+ * The original theme this is built on is available here:
+ * https://github.com/ajaxorg/ace/blob/master/src/theme/solarized_dark-css.js
+ *
+ * The following modifications were made:
+ *   - Added three darker colors: `base04`, `base05`, `base06`
+ *   - Lightened the blue color to increase contrast
+ *   - Gave Markdown headings a different color than standard text
+ *   - Made inline **bold** and _italic_ actually display as bold or italic
+ */
+
+:root {
+    --editor-font-size: 16px;
+    --editor-font-family: "Hack", "Menlo", "Consolas", "Monaco", "Adwaita Mono", "Liberation Mono", "Lucida Console", monospace;
+    --solarized-base06: #00141b;
+    --solarized-base05: #001c24;
+    --solarized-base04: #00232d;
+    --solarized-base03: #002b36;
+    --solarized-base02: #073642;
+    --solarized-base01: #586e75;
+    --solarized-base00: #657b83;
+    --solarized-base0: #839496;
+    --solarized-base1: #93a1a1;
+    --solarized-base2: #eee8d5;
+    --solarized-base3: #fdf6e3;
+    --solarized-yellow: #b58900;
+    --solarized-orange: #cb4b16;
+    --solarized-red: #dc322f;
+    --solarized-magenta: #d33682;
+    --solarized-violet: #6c71c4;
+    --solarized-blue: #1aa5ff;
+    --solarized-cyan: #2aa198;
+    --solarized-green: #859900;
+}
+
+.ace_editor {
+    font-family: var(--editor-font-family);
+    font-size: var(--editor-font-size);
+}
+
+.ace-solarized-dark .ace_gutter {
+    background: var(--solarized-base05);
+    color: var(--solarized-base01);
+}
+
+.ace-solarized-dark .ace_print-margin {
+    width: 1px;
+    background: var(--solarized-base04);
+}
+
+.ace-solarized-dark {
+    background: var(--solarized-base06);
+    color: var(--solarized-base2);
+}
+
+.ace-solarized-dark .ace_entity.ace_other.ace_attribute-name,
+.ace-solarized-dark .ace_storage {
+    color: #839496;
+}
+
+.ace-solarized-dark .ace_cursor,
+.ace-solarized-dark .ace_string.ace_regexp {
+    color: var(--solarized-blue);
+}
+
+.ace-solarized-dark .ace_marker-layer .ace_active-line,
+.ace-solarized-dark .ace_marker-layer .ace_selection {
+    background: var(--solarized-base04);
+}
+
+.ace-solarized-dark.ace_multiselect .ace_selection.ace_start {
+    box-shadow: 0 0 3px 0px #002B36;
+}
+
+.ace-solarized-dark .ace_marker-layer .ace_step {
+    background: rgb(102, 82, 0);
+}
+
+.ace-solarized-dark .ace_marker-layer .ace_bracket {
+    margin: -1px 0 0 -1px;
+    border: 1px solid rgba(147, 161, 161, 0.50);
+}
+
+.ace-solarized-dark .ace_gutter-active-line {
+    background-color: #0d3440;
+}
+
+.ace-solarized-dark .ace_marker-layer .ace_selected-word {
+    border: 1px solid #073642;
+}
+
+.ace-solarized-dark .ace_invisible {
+    color: rgba(147, 161, 161, 0.50);
+}
+
+.ace-solarized-dark .ace_keyword,
+.ace-solarized-dark .ace_meta,
+.ace-solarized-dark .ace_support.ace_class,
+.ace-solarized-dark .ace_support.ace_type {
+    color: #859900;
+}
+
+.ace-solarized-dark .ace_constant.ace_character,
+.ace-solarized-dark .ace_constant.ace_other {
+    color: #CB4B16;
+}
+
+.ace-solarized-dark .ace_constant.ace_language {
+    color: #B58900;
+}
+
+.ace-solarized-dark .ace_constant.ace_numeric {
+    color: #D33682;
+}
+
+.ace-solarized-dark .ace_fold {
+    background-color: #268BD2;
+    border-color: #93A1A1;
+}
+
+.ace-solarized-dark .ace_entity.ace_name.ace_function,
+.ace-solarized-dark .ace_entity.ace_name.ace_tag,
+.ace-solarized-dark .ace_support.ace_function,
+.ace-solarized-dark .ace_variable,
+.ace-solarized-dark .ace_variable.ace_language {
+    color: #268BD2;
+}
+
+.ace-solarized-dark .ace_string {
+    color: #2AA198;
+}
+
+.ace-solarized-dark .ace_comment {
+    font-style: italic;
+    color: #657B83;
+}
+
+.ace-solarized-dark .ace_indent-guide {
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWNg0Db1ZVCxc/sPAAd4AlUHlLenAAAAAElFTkSuQmCC") right repeat-y;
+}
+
+.ace-solarized-dark .ace_indent-guide-active {
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQIW2PQ1dX9zzBz5sz/ABCcBFFentLlAAAAAElFTkSuQmCC") right repeat-y;
+}
+
+/* # Headings */
+.ace-solarized-dark .ace_heading {
+    color: var(--solarized-blue);
+}
+
+/* **bold** text */
+.ace-solarized-dark .ace_string.ace_strong {
+    font-weight: bold;
+}
+
+/* _italic_ text */
+.ace-solarized-dark .ace_string.ace_emphasis {
+    font-style: italic;
+}
+
+/* `code blocks` */
+.ace-solarized-dark .ace_support.ace_function {
+    color: var(--solarized-magenta);
+}
+
+/* > Blockquotes */
+.ace-solarized-dark .ace_blockquote {
+    color: var(--solarized-green);
+}
+
+/* List item prefixes: both numbers (1.) and bullets (-, *, and +) */
+.ace-solarized-dark .ace_markup.ace_list {
+    color: var(--solarized-yellow);
+}

--- a/plugins/ace-editor/bear-ace-theme.css
+++ b/plugins/ace-editor/bear-ace-theme.css
@@ -66,8 +66,7 @@
     color: var(--solarized-blue);
 }
 
-.ace-solarized-dark .ace_marker-layer .ace_active-line,
-.ace-solarized-dark .ace_marker-layer .ace_selection {
+.ace-solarized-dark .ace_marker-layer .ace_active-line {
     background: var(--solarized-base04);
 }
 


### PR DESCRIPTION
This plugin replaces the `<textarea>` used for editing page and post content with the [Ace code editor](https://ace.c9.io/) component. It's useful for previewing syntax and making sure your post looks correct before publishing.

It also includes a slightly customized version of Ace's solarized_dark theme that happens to match Bear's UI very well. The modifications I made to the theme make the editor background darker for better contrast, syntax highlighting for Markdown headers, and a few other slight contrast improvements.

## Usage

The following two tags are required to load first in the "Dashboard footer content" field. These initialize the ace-editor component and load the Markdown syntax parsing module.

```
<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.43.4/src-min/ace.js"></script>
<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.43.4/src-min/mode-markdown.js"></script>
```

Then add the contents of `bear-ace-theme.css` in a `<style>` tag and the contents of `ace-editor-loader.js` in a `<script>` tag. I can't add `<script src="...">` links yet, since this isn't even merged yet :) 

If you don't want to use the solarized_dark theme, remove `editor.setTheme("ace/theme/solarized_dark");` from the JS file and don't add the `bear-ace-theme.css` file. The editor will then default to a light theme.

## Preview

<img width="1728" height="1214" alt="bear-blog-ace-editor-plugin-preview" src="https://github.com/user-attachments/assets/564b7871-309a-4204-8543-3edf2084400a" />
