### PR TITLE
Update contributions guidelines to use Baseline Widely available

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -23,7 +23,6 @@ In the README.md file:
 - Push to your fork
 - Open a PR with a description of what your plugin does and how to use it
 
-
 ## Code standards
 
 ### 1. Use strict mode with IIFE
@@ -58,7 +57,8 @@ Check for specific page contexts before running (e.g., `document.body.classList.
 
 ### 6. Compatibility
 
-- Avoid ES6+ features that aren't widely supported (or document browser requirements)
+- Stick to features that are in [Baseline Widely available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) and are fully supported for greater than 90% of users. You can tell a feature is in Baseline Widely available if there is a green box at the top of its MDN page saying it's in Baseline Widely available.
+- You may use features that are less widely-supported as long as the fallback logic works or you use a [ponyfill](https://ponyfill.com/)
 - Don't override native prototypes
 - Test across major browsers
 
@@ -74,4 +74,3 @@ Add a comment block at the top of the pugin file with the following details:
  Author URI: 
 */
 ```
-


### PR DESCRIPTION
The current guidelines say not to use "ES6+ features that aren't widely supported". However, there are no features of es6 that aren't widely supported. It has [availability for 95% of internet users](https://caniuse.com/es6). In fact, with the exception of top-level await, [es2022](https://caniuse.com/?feats=mdn-javascript_builtins_array_at%2Cmdn-javascript_builtins_regexp_hasindices%2Cmdn-javascript_builtins_object_hasown%2Cmdn-javascript_builtins_error_cause%2Cmdn-javascript_operators_await_top_level%2Cmdn-javascript_classes_private_class_fields%2Cmdn-javascript_classes_private_class_methods%2Cmdn-javascript_classes_static_class_fields%2Cmdn-javascript_classes_static_initialization_blocks) is available to 95% of internet users.

Choosing features that are in [Baseline Widely available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) is the more modern way to choose which features have browser support.